### PR TITLE
remove serverless part. change github links to new repo location afte…

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -71,7 +71,7 @@ url = "https://www.puzzle.ch"
 
 [params]
 copyright = "Puzzle ITC GmbH"
-github_repo = "https://github.com/puzzle/quarkus-techlab"
+github_repo = "https://github.com/acend/quarkus-techlab"
 github_branch = "master"
 
 lab_code_basedir = "/code/"
@@ -134,7 +134,7 @@ footer_about_disable = true
 [[params.links.developer]]
 name = "GitHub"
 icon = "fab fa-github"
-url = "https://github.com/puzzle/quarkus-techlab"
+url = "https://github.com/acend/quarkus-techlab"
 
 [[params.links.user]]
 name = "Twitter"

--- a/content/en/docs/11.0/111_funqy.md
+++ b/content/en/docs/11.0/111_funqy.md
@@ -2,6 +2,7 @@
 title: "11.1 Quarkus serverless with Funqy"
 linkTitle: "11.1 Quarkus serverless with Funqy"
 weight: 1110
+onlyWhenNot: mobi
 sectionnumber: 11.1
 description: >
     Quarkus serverless with Funqy

--- a/content/en/docs/11.0/_index.md
+++ b/content/en/docs/11.0/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "11. Serverless"
 weight: 11
+onlyWhenNot: mobi
 sectionnumber: 11
 description: >
   Testing the serverless abilities of Quarkus.


### PR DESCRIPTION
* remove serverless part. 
* change github links to new repo location after ownership transfer.