### PR TITLE
fix: use correct syntax for RETURNING in query

### DIFF
--- a/content/en/docs/02.0/25_reactive-programming.md
+++ b/content/en/docs/02.0/25_reactive-programming.md
@@ -356,7 +356,7 @@ public static Uni<SensorMeasurement> findById(PgPool client, Long id) {
 }
 
 public Uni<SensorMeasurement> save(PgPool client) {
-    return client.preparedQuery("INSERT INTO sensormeasurements (data, time) VALUES ($1, $2) RETURNING (id, data, time)")
+    return client.preparedQuery("INSERT INTO sensormeasurements (data, time) VALUES ($1, $2) RETURNING id, data, time")
             .execute(Tuple.of(data, time.atOffset(ZoneOffset.UTC)))
             .onItem().transform(RowSet::iterator)
             .onItem().transform(iterator -> iterator.hasNext() ? new SensorMeasurement(iterator.next()) : null);

--- a/solution/quarkus-reactive-rest-producer/src/main/java/ch/puzzle/quarkustechlab/reactiverest/producer/entity/SensorMeasurement.java
+++ b/solution/quarkus-reactive-rest-producer/src/main/java/ch/puzzle/quarkustechlab/reactiverest/producer/entity/SensorMeasurement.java
@@ -39,10 +39,10 @@ public class SensorMeasurement {
     }
 
     public Uni<SensorMeasurement> save(PgPool client) {
-        return client.preparedQuery("INSERT INTO sensormeasurements (data, time) VALUES ($1, $2) RETURNING (id, data, time)")
+        return client.preparedQuery("INSERT INTO sensormeasurements (data, time) VALUES ($1, $2) RETURNING id, data, time")
                 .execute(Tuple.of(data, time.atOffset(ZoneOffset.UTC)))
                 .onItem().transform(RowSet::iterator)
-                .onItem().transform(iterator -> iterator.hasNext() ? this : null);
+                .onItem().transform(iterator -> iterator.hasNext() ? new SensorMeasurement(iterator.next()) : null);
     }
 
     public static Uni<SensorMeasurement> getLatest(PgPool client) {


### PR DESCRIPTION
Using the proposed code snippet in `25_reactive_programming.md#359` resulted in an exception being thrown:

```
Details:
        Error id 291c8a46-0a80-41b7-99d8-6d9287691027-8, java.util.NoSuchElementException: Column id does not exist
Decorate (Source code):
        Exception in SensorMeasurement.java:26
          24  
          25      public SensorMeasurement(Row row) {
        → 26          this.id = row.getLong("id");
          27          this.data = row.getDouble("data");
          28          this.time = Instant.from(row.getOffsetDateTime("time"));
Stack:
        java.util.NoSuchElementException: Column id does not exist
        at io.vertx.sqlclient.Row.getLong(Row.java:125)
        at io.vertx.mutiny.sqlclient.Row.getLong(Row.java:138)
        at org.acme.entity.SensorMeasurement.<init>(SensorMeasurement.java:26)
        at org.acme.entity.SensorMeasurement.lambda$save$2(SensorMeasurement.java:58)
```

The actual solution in the `/solutions` folder does not throw the exception, but it does not return the new `id` of the `SensorMeasurement`.

The list of columns in `RETURNING` should not be placed in paranthesis. 
See https://www.postgresql.org/docs/current/dml-returning.html 
(unfortunatly - it has no example with multiple columns)
        
